### PR TITLE
Fix: Validator best number value

### DIFF
--- a/src/components/validators/validators.jsx
+++ b/src/components/validators/validators.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import getApi from "../libs/api";
+import getApi from "../../libs/api";
 
 export default function Validators() {
   const [validators, setValidators] = useState([]);
@@ -23,8 +23,12 @@ export default function Validators() {
       }
     };
 
-    getConnectedPeers();
-    return () => unsubscribeAll && unsubscribeAll();
+    const timer = setInterval(getConnectedPeers, 10000);
+
+    return () => {
+      clearInterval(timer);
+      unsubscribeAll && unsubscribeAll();
+    };
   }, []);
 
   return (

--- a/src/components/validators/validators.test.js
+++ b/src/components/validators/validators.test.js
@@ -1,0 +1,6 @@
+import { render } from "@testing-library/react";
+import Validators from "./validators";
+
+test("renders Validators component without errors", () => {
+  render(<Validators />);
+});

--- a/src/routes/home.jsx
+++ b/src/routes/home.jsx
@@ -1,6 +1,6 @@
 import Blocks from "../components/blocks";
 import Snapshot from "../components/snapshot";
-import Validators from "../components/validators";
+import Validators from "../components/validators/validators";
 
 export default function Home() {
   return (


### PR DESCRIPTION
Problem: Validator best number and hash were not updating to reflect the most current activity on the network.

Solution: Polled the function that returns connected peers to run every ten seconds. Ten seconds is the same interval value used by Polkadot explorer to refresh validators list.

Fixes #1201614135675559