### PR TITLE
fix: display bar timestamp as is

### DIFF
--- a/src/components/charts/bar-chart.js
+++ b/src/components/charts/bar-chart.js
@@ -26,13 +26,7 @@ export default class Chart extends Component {
           tooltip: {},
           xAxis: {
             type: "category",
-            data: this.props.chartData.map(
-              (c) =>
-                `${new Date(c.timestamp)
-                  .toISOString()
-                  .slice(0, 19)
-                  .replace("T", " ")} (+UTC)`
-            ),
+            data: this.props.chartData.map((c) => c.timestamp),
             show: false,
           },
           yAxis: {

--- a/src/components/extrinsics/history.js
+++ b/src/components/extrinsics/history.js
@@ -46,7 +46,7 @@ export default function ExtrinsicsHistory() {
 
         for (let date in groupedTimestamps) {
           dataset.push({
-            timestamp: new Date(date).toISOString(),
+            timestamp: date, // new Date(date).toISOString(),
             total: groupedTimestamps[date].length,
           });
         }


### PR DESCRIPTION
display chart bar timestamp without conversion to avoid time difference issues with respect to browser.